### PR TITLE
monit.log rotates by separate default-standard config

### DIFF
--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,4 +1,4 @@
-/var/log/monit.log /var/log/rollbar-agent.log {
+/var/log/rollbar-agent.log {
   daily
   rotate 5
   compress


### PR DESCRIPTION
fix logrotate error `error: rollbar-agent:1 duplicate log entry for /var/log/monit.log`